### PR TITLE
add compability for lib version before 1.3.0 while keeping latest updates

### DIFF
--- a/webp/ldflags.go
+++ b/webp/ldflags.go
@@ -1,0 +1,6 @@
+//go:build !1.2.4
+
+package webp
+
+// #cgo LDFLAGS: -lwebp -lsharpyuv -lm
+import "C"

--- a/webp/ldflags_1.2.4.go
+++ b/webp/ldflags_1.2.4.go
@@ -1,0 +1,6 @@
+//go:build 1.2.4
+
+package webp
+
+// #cgo LDFLAGS: -lwebp -lm
+import "C"

--- a/webp/webp.go
+++ b/webp/webp.go
@@ -3,8 +3,6 @@
 package webp
 
 /*
-#cgo LDFLAGS: -lwebp -lsharpyuv -lm
-
 #include <stdlib.h>
 #include <webp/encode.h>
 

--- a/webp/webp_test.go
+++ b/webp/webp_test.go
@@ -233,7 +233,7 @@ func TestEncodeRGBAWithProgressCanceled(t *testing.T) {
 		t.Fatalf("got error: %v", err)
 	}
 
-	f := util.CreateFile("TestEncodeRGBAWithProgress.webp")
+	f := util.CreateFile("TestEncodeRGBAWithProgressCanceled.webp")
 	w := bufio.NewWriter(f)
 	defer func() {
 		w.Flush()
@@ -322,7 +322,7 @@ func TestEncodeRGBWithProgressCanceled(t *testing.T) {
 		t.Fatalf("got error: %v", err)
 	}
 
-	f := util.CreateFile("TestEncodeRGBWithProgress.webp")
+	f := util.CreateFile("TestEncodeRGBWithProgressCanceled.webp")
 	w := bufio.NewWriter(f)
 	defer func() {
 		w.Flush()
@@ -377,7 +377,7 @@ func TestEncodeYUVAWithProgress(t *testing.T) {
 		return
 	}
 
-	f := util.CreateFile("TestEncodeYUVA.webp")
+	f := util.CreateFile("TestEncodeYUVAWithProgress.webp")
 	w := bufio.NewWriter(f)
 	defer func() {
 		w.Flush()
@@ -408,7 +408,7 @@ func TestEncodeYUVAWithProgressCanceled(t *testing.T) {
 		return
 	}
 
-	f := util.CreateFile("TestEncodeYUVA.webp")
+	f := util.CreateFile("TestEncodeYUVAWithProgressCanceled.webp")
 	w := bufio.NewWriter(f)
 	defer func() {
 		w.Flush()
@@ -460,7 +460,7 @@ func TestEncodeGrayWithProgress(t *testing.T) {
 		p.SetGray(0, i, color.Gray{uint8(float32(i) / 10 * 255)})
 	}
 
-	f := util.CreateFile("TestEncodeGray.webp")
+	f := util.CreateFile("TestEncodeGrayWithProgress.webp")
 	w := bufio.NewWriter(f)
 	defer func() {
 		w.Flush()
@@ -487,7 +487,7 @@ func TestEncodeGrayWithProgressCanceled(t *testing.T) {
 		p.SetGray(0, i, color.Gray{uint8(float32(i) / 10 * 255)})
 	}
 
-	f := util.CreateFile("TestEncodeGray.webp")
+	f := util.CreateFile("TestEncodeGrayWithProgressCanceled.webp")
 	w := bufio.NewWriter(f)
 	defer func() {
 		w.Flush()


### PR DESCRIPTION
* Also fixed some unit test where files were being overwritten
* Users using the libwebp version 1.3.0+ won't need to do anything, for users using a previous version of the library you can run go build or go run with -tags '1.2.4' and it will use switch C flags to old ways 